### PR TITLE
feat: add AWS architecture example

### DIFF
--- a/examples/aws-icons.md
+++ b/examples/aws-icons.md
@@ -1,0 +1,78 @@
+# AWS Architecture Diagramming with XYFlow
+
+This guide explains how to add AWS service icons to XYFlow diagrams, run the example, and extend it into a full diagramming tool. A React implementation is available at `examples/react/src/examples/AwsArchitecture`.
+
+## AWS Icons as Custom Nodes
+
+1. Download the official AWS Architecture Icons and place the assets in your project (e.g., `src/icons/`).
+2. Create a custom node component:
+
+### React
+```jsx
+import { memo } from 'react';
+import ec2 from '../icons/Amazon-EC2.svg';
+
+function AwsNode({ data, selected }) {
+  return (
+    <div style={{ padding: 4, border: selected ? '1px solid #1a192b' : 0 }}>
+      <img src={data.icon || ec2} alt={data.label} width={50} />
+      <div style={{ textAlign: 'center' }}>{data.label}</div>
+    </div>
+  );
+}
+
+export default memo(AwsNode);
+```
+
+### Svelte
+```svelte
+<script lang="ts">
+  export let data: { label: string; icon: string };
+</script>
+
+<div class:selected>
+  <img src={data.icon} alt={data.label} width="50" />
+  <div>{data.label}</div>
+</div>
+
+<style>
+  div.selected { border: 1px solid #1a192b; }
+  div { padding: 4px; text-align: center; }
+</style>
+```
+
+3. Register the node type:
+```jsx
+import AwsNode from './nodes/AwsNode';
+const nodeTypes = { aws: AwsNode };
+
+<ReactFlow nodeTypes={nodeTypes} ... />
+```
+
+4. Instantiate nodes with icons:
+```jsx
+const initialNodes = [
+  {
+    id: 'ec2',
+    type: 'aws',
+    position: { x: 50, y: 100 },
+    data: { label: 'Amazon EC2', icon: ec2 },
+  },
+];
+```
+
+## Running the Example
+
+1. Create a React project: `npx create-vite@latest xyflow-demo -- --template react`.
+2. Install XYFlow: `npm install @xyflow/react`.
+3. Replace `src/App.jsx` with the sample component and import `@xyflow/react/dist/style.css`.
+4. Run the dev server: `npm run dev` and open the printed URL.
+
+For Svelte, use the Svelte template, install `@xyflow/svelte`, update `App.svelte`, and run `npm run dev`.
+
+## Building a Diagramming Product
+
+- Use XYFlow as the canvas and define node types for services, databases, etc.
+- Create a palette or sidebar for drag-and-drop components.
+- Implement persistence, export (PNG/SVG/JSON), and optional real-time collaboration.
+

--- a/examples/react/src/App/routes.ts
+++ b/examples/react/src/App/routes.ts
@@ -59,6 +59,7 @@ import DevTools from '../examples/DevTools';
 import Redux from '../examples/Redux';
 import MovingHandles from '../examples/MovingHandles';
 import DetachedHandle from '../examples/DetachedHandle';
+import AwsArchitecture from '../examples/AwsArchitecture';
 
 export interface IRoute {
   name: string;
@@ -371,6 +372,11 @@ const routes: IRoute[] = [
     name: 'useKeyPress',
     path: 'use-key-press',
     component: UseKeyPress,
+  },
+  {
+    name: 'AWS Architecture',
+    path: 'aws-architecture',
+    component: AwsArchitecture,
   },
 ];
 

--- a/examples/react/src/examples/AwsArchitecture/index.tsx
+++ b/examples/react/src/examples/AwsArchitecture/index.tsx
@@ -1,0 +1,75 @@
+import { useCallback } from 'react';
+import {
+  ReactFlow,
+  MiniMap,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+} from '@xyflow/react';
+
+const ec2Url = 'https://d1.awsstatic.com/webteam/architecture-icons/64/Arch_Amazon-EC2_64.svg';
+
+function AwsNode({ data, selected }: any) {
+  return (
+    <div style={{ padding: 4, border: selected ? '1px solid #1a192b' : 0 }}>
+      <img src={data.icon || ec2Url} alt={data.label} width={50} />
+      <div style={{ textAlign: 'center' }}>{data.label}</div>
+    </div>
+  );
+}
+
+const nodeTypes = { aws: AwsNode };
+
+const initialNodes = [
+  {
+    id: 'ec2',
+    type: 'aws',
+    position: { x: 0, y: 0 },
+    data: { label: 'Amazon EC2', icon: ec2Url },
+  },
+];
+
+export default function AwsArchitecture() {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+  const onConnect = useCallback(
+    (params: any) => setEdges((eds) => addEdge(params, eds)),
+    []
+  );
+
+  const addNode = () => {
+    const id = (nodes.length + 1).toString();
+    setNodes((nds) =>
+      nds.concat({
+        id,
+        type: 'aws',
+        position: { x: Math.random() * 400, y: Math.random() * 200 },
+        data: { label: `Service ${id}`, icon: ec2Url },
+      })
+    );
+  };
+
+  return (
+    <div style={{ width: '100%', height: 500 }}>
+      <button onClick={addNode} style={{ marginBottom: 8 }}>
+        Add EC2 Node
+      </button>
+      <ReactFlow
+        nodeTypes={nodeTypes}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React example demonstrating AWS service nodes and node creation controls
- expose example via route entry
- reference example in AWS icon guide

## Testing
- `pnpm lint` *(fails: @xyflow/react#lint command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68aa85f390ac83209f5876f032016e64